### PR TITLE
feat: add/set no-color feature for testing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[alias]
+# equivalent to cargo test with no-color in this project
+r = "run -- --features no-color"
+t = "test --features no-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,25 @@ indexmap = "2"
 colored = "2"
 strip-ansi-escapes = "0.2"
 
+[features]
+# Don't add ANSI escapes, which is useful for testing.
+no-color = ["colored/no-color"]
+
+# You should use `--features no-color` to run
+# these test. Or run `cargo t` as a shortcut.
+[[test]]
+name = "golden_master_test"
+path = "./tests/golden_master_test.rs"
+required-features = ["no-color"]
+[[test]]
+name = "mocking_project"
+path = "./tests/mocking_project.rs"
+required-features = ["no-color"]
+[[test]]
+name = "parsing"
+path = "./tests/parsing.rs"
+required-features = ["no-color"]
+
 [dev-dependencies]
 pretty_assertions = "1.4.0"
 insta = "1.33"


### PR DESCRIPTION
fix https://github.com/josecelano/cargo-pretty-test/issues/13 and suppress https://github.com/josecelano/cargo-pretty-test/pull/14

With this PR, you can use any of these commands to run tests:
* `cargo test --features no-color`
* `cargo test -F no-color`
* `cargo t`
* `cargo test --all-features` (which CI does)