### PR TITLE
feat: reinterpret `-q` or `--quite` to show raw output from cargo test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,11 +13,11 @@ name = "cargo-pretty-test"
 version = "0.2.3"
 dependencies = [
  "colored",
+ "console",
  "indexmap",
  "insta",
  "pretty_assertions",
  "regex-lite",
- "strip-ansi-escapes",
  "termtree",
 ]
 
@@ -50,6 +50,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width",
  "windows-sys 0.45.0",
 ]
 
@@ -177,24 +178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "regex-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,51 +203,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.12"
+name = "unicode-width"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vte"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
-dependencies = [
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
-dependencies = [
- "proc-macro2",
- "quote",
-]
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ termtree = "0.4"
 regex-lite = "0.1"
 indexmap = "2"
 colored = "2"
-strip-ansi-escapes = "0.2"
+console = "0.15"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"


### PR DESCRIPTION
By default, `-q` is not passed, meaning raw output is forwarded as cargo test is running.
If `-q` is passed in, don't display raw output, show test tree directly.

Note: this commit also makes `--color` default to `always` because not `-q` is the default, and we want forwarding looks pretty in color.

> Press Enter to clear the screen to show the test tree: 

https://github.com/josecelano/cargo-pretty-test/assets/25300418/a6f392e5-cd9e-4a17-a362-3a53e85f10c4



---

Some questions:
* Do we need this? / Do we need both the outputs from two CLIs?
    * Yes, because watching `cargo test` prints is fun and it's important to know the execution details in CI
    * No, why not run `cargo test` before this tool?
* Do we need to stop befor viewing the output from pretty-test?
