### PR TITLE
fix snapshot test; redirects stderr to $GITHUB_STEP_SUMMARY

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -114,5 +114,5 @@ jobs:
           cargo install --path .
           cargo pretty-test -F "no-color" --color=always
           echo '```text' >> $GITHUB_STEP_SUMMARY
-          echo "$(cargo pretty-test -F "no-color" --color=never)" >> $GITHUB_STEP_SUMMARY
+          echo "$(cargo pretty-test -F "no-color" --color=never)" >> $GITHUB_STEP_SUMMARY 2>&1
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Run in CI as a summary: [demo](https://github.com/josecelano/cargo-pretty-test/a
           cargo install cargo-pretty-test
           cargo pretty-test --color=always
           echo '```text' >> $GITHUB_STEP_SUMMARY
-          echo "$(cargo pretty-test --color=never)" >> $GITHUB_STEP_SUMMARY
+          echo "$(cargo pretty-test --color=never)" >> $GITHUB_STEP_SUMMARY 2>&1
           echo '```' >> $GITHUB_STEP_SUMMARY
 ```
 

--- a/tests/mocking_project.rs
+++ b/tests/mocking_project.rs
@@ -68,12 +68,12 @@ fn snapshot_testing_for_parsed_output() {
         .iter()
         .copied()
         .zip(pos.iter().copied().skip(1).chain(Some(failure_tests.len())))
-        .map(|(a, b)| &failure_tests[a..b])
+        .map(|(a, b)| failure_tests[a..b].trim())
         .collect();
     failure_info.sort_unstable();
     snap!(failure_info, @r###"
     [
-        "---- submod::panic::panicked stdout ----\nthread 'submod::panic::panicked' panicked at tests/integration/src/lib.rs:11:13:\nexplicit panic\n\n",
+        "---- submod::panic::panicked stdout ----\nthread 'submod::panic::panicked' panicked at tests/integration/src/lib.rs:11:13:\nexplicit panic",
         "---- submod::panic::should_panic_but_didnt stdout ----\nnote: test did not panic as expected",
     ]
     "###);


### PR DESCRIPTION
This won't fix https://github.com/josecelano/cargo-pretty-test/issues/46 , but helps to solve the current failed snapshot test which is caused by random execution order and thus potential trailing newlines.

And this PR also redirects stderr to `$GITHUB_STEP_SUMMARY` in case any error occurs and we want to see the exact failure in that round.